### PR TITLE
Preparations for merging into the Linux tree

### DIFF
--- a/cef168.h
+++ b/cef168.h
@@ -1,16 +1,11 @@
 #ifndef CEF168_CEF168_H
 #define CEF168_CEF168_H
 
-#define CEF168_NAME "cef168"
-
 #define CEF168_V4L2_CID_CUSTOM(ctrl) \
 	((V4L2_CID_USER_BASE | 168) + custom_##ctrl)
 
-enum { custom_lens_id, custom_data, custom_focus_range, custom_calibrate };
+enum { custom_lens_id, custom_data, custom_calibrate };
 
-/**
- * cef168 data structure
- */
 struct cef168_data {
 	__u8 lens_id;
 	__u8 moving : 1;
@@ -22,11 +17,8 @@ struct cef168_data {
 	__u16 focus_distance_min;
 	__u16 focus_distance_max;
 	__u8 crc8;
-} __attribute__((packed));
+} __packed;
 
-/*
- * cef168 I2C protocol commands
- */
 #define INP_CALIBRATE 0x22
 #define INP_SET_FOCUS 0x80
 #define INP_SET_FOCUS_P 0x81
@@ -36,9 +28,5 @@ struct cef168_data {
 #define INP_SET_APERTURE_N 0x7C
 
 #define CEF_CRC8_POLYNOMIAL 168
-
-#ifdef DECLARE_CRC8_TABLE
-DECLARE_CRC8_TABLE(cef168_crc8_table);
-#endif
 
 #endif //CEF168_CEF168_H

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -30,10 +30,10 @@ If the lens does not focus and the image remains static when running `rpicam-hel
 Check the range with the following command:
 
 ```shell
-v4l2-ctl -d $DEV_LENS -C focus_range
+v4l2-ctl -d $DEV_LENS --all | awk '/focus_absolute/ {print $6;}'
 ```
 
-A valid, calibrated lens will return a positive value (e.g., 1203). If the result is 0 or greater than 32768, the lens has not been calibrated.
+A valid, calibrated lens will return a positive value (e.g., `max=1203`). If the result is 0 or 32767, the lens has not been calibrated.
 
 Calibrate the lens as described [here](../readme.md#calibration). You only need to do this once per lens. After calibration, run the focus range check again to confirm proper setup.
 


### PR DESCRIPTION
 - moved variable declaration at the beginning of the function;
 - removed kerneldoc from structures;
 - removed control id check as the core handles this for us;
 - removed Power Management Runtime (pm_runtime_*) calls as redundant;
 - condition on declared v4l2 controls in linux header file;
 - removed "focus_range" custom control, instead modified the range of the standard "focus_absolute"