### PR TITLE
Added support for OneInchEye and imx283

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -16,7 +16,7 @@ else
 fi
 
 # Determine Raspberry Pi Linux kernel Git hash
-commit=$(wget --quiet -O - "https://raw.githubusercontent.com/raspberrypi/firmware/refs/tags/$upstream_version/extra/git_hash")
+: "${commit:=$(wget --quiet -O - "https://raw.githubusercontent.com/raspberrypi/firmware/refs/tags/${upstream_version}/extra/git_hash")}"
 if [ -z "$commit" ]; then
     echo "Raspberry Pi Linux kernel Git hash is not determined" >&2
     exit 1
@@ -29,7 +29,7 @@ declare -A downloaded_files
 
 download() {
     local file="$1"
-    wget --no-verbose --backups=5 "https://raw.githubusercontent.com/raspberrypi/linux/$commit/arch/arm/boot/dts/overlays/$file"
+    wget --no-verbose --backups=5 "https://raw.githubusercontent.com/raspberrypi/linux/${commit}/arch/arm/boot/dts/overlays/${file}"
     return $?
 }
 

--- a/download.sh
+++ b/download.sh
@@ -24,12 +24,14 @@ else
     echo "Raspberry Pi Linux kernel Git hash: $commit"
 fi
 
+: "${download_path:="https://raw.githubusercontent.com/raspberrypi/linux/${commit}/arch/arm/boot/dts/overlays/"}"
+
 # Download device tree overlay files
 declare -A downloaded_files
 
 download() {
     local file="$1"
-    wget --no-verbose --backups=5 "https://raw.githubusercontent.com/raspberrypi/linux/${commit}/arch/arm/boot/dts/overlays/${file}"
+    wget --no-verbose --backups=5 "${download_path}${file}"
     return $?
 }
 

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ For tested and **ready-to-use** assemblies, refer to the PDF guides below. These
 
  - [Raspberry Pi High Quality Camera (CS Mount variant)](https://docs.pinefeat.co.uk/cef168-assembly-rpi-hq-camera.pdf)
  - [Arducam IMX708 Camera Module (M12 Mount variant)](https://docs.pinefeat.co.uk/cef168-assembly-arducam-imx708.pdf)
+ - [OneInchEye Camera Board](https://docs.pinefeat.co.uk/cef168-assembly-oneincheye-camera.pdf)
 
 ![Assembly of Pinefeat Lens Controller and Arducam IMX708 Camera Module](https://docs.pinefeat.co.uk/cef168-assembly-arducam-imx708.jpg)
 
@@ -105,6 +106,7 @@ You will need to repeat this operation if you upgrade your Raspberry Pi firmware
 | Camera sensor | Line in `/boot/firmware/config.txt` |
 |---------------|-------------------------------------|
 | imx219        | `dtoverlay=imx219,vcm`              |
+| imx283        | `dtoverlay=imx283`                  |
 | imx296        | `dtoverlay=imx296`                  |
 | imx477        | `dtoverlay=imx477`                  |
 | imx519        | `dtoverlay=imx519`                  |

--- a/sensors.txt
+++ b/sensors.txt
@@ -1,6 +1,6 @@
 imx219
 #imx258
-#imx283
+imx283
 #imx290
 imx296
 #imx327


### PR DESCRIPTION
## OneInchEye

Please note: The IMX283 sensor overlay is not yet included in the latest Raspberry Pi firmware and will be available in the next release. In the meantime, it can be downloaded and configured as follows:

```sh
commit=$(wget -q -O - "https://raw.githubusercontent.com/raspberrypi/firmware/refs/heads/next/extra/git_hash") \
./configure.sh imx283
```

## StarlightEye

Similarly, the IMX585 sensor overlay is not yet part of the Linux source tree, but it can be downloaded and configured as follows:

```sh
download_path="https://raw.githubusercontent.com/will127534/imx585-v4l2-driver/refs/heads/main/" \
./configure.sh imx585
```